### PR TITLE
Fix: fix error field 'to'

### DIFF
--- a/smtp_service.go
+++ b/smtp_service.go
@@ -17,24 +17,25 @@ func newSmtpService(cl *Client) *SmtpService {
 	return &SmtpService{client: cl}
 }
 
+type EmailTemplate struct {
+	ID        string                 `json:"id"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+type User struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
 type SendEmailParams struct {
-	Html     string `json:"html,omitempty"`
-	Text     string `json:"text,omitempty"`
-	Template *struct {
-		ID        string                 `json:"id"`
-		Variables map[string]interface{} `json:"variables"`
-	} `json:"template"`
-	AutoPlainText bool   `json:"auto_plain_text"`
-	Subject       string `json:"subject"`
-	From          struct {
-		Name  string `json:"name"`
-		Email string `json:"email"`
-	} `json:"from"`
-	To struct {
-		Name  string `json:"name"`
-		Email string `json:"email"`
-	} `json:"to"`
-	Attachments map[string]string `json:"attachments"`
+	Html          string            `json:"html,omitempty"`
+	Text          string            `json:"text,omitempty"`
+	Template      *EmailTemplate    `json:"template"`
+	AutoPlainText bool              `json:"auto_plain_text"`
+	Subject       string            `json:"subject"`
+	From          User              `json:"from"`
+	To            []User            `json:"to"`
+	Attachments   map[string]string `json:"attachments"`
 }
 
 func (service *SmtpService) SendMessage(ctx context.Context, params SendEmailParams) (string, error) {

--- a/smtp_service_test.go
+++ b/smtp_service_test.go
@@ -17,26 +17,19 @@ func (suite *SendpulseTestSuite) TestSmtpService_Send() {
 		}`)
 	})
 
+	user := []User{{Name: "Andy", Email: "Forest"}}
+
 	id, err := suite.client.SMTP.SendMessage(context.Background(), SendEmailParams{
 		Html:          "<h1>Hello</h1>",
 		Text:          "",
 		Template:      nil,
 		AutoPlainText: false,
 		Subject:       "Notification",
-		From: struct {
-			Name  string `json:"name"`
-			Email string `json:"email"`
-		}{
+		From: User{
 			Name:  "Alex",
 			Email: "Brown",
 		},
-		To: struct {
-			Name  string `json:"name"`
-			Email string `json:"email"`
-		}{
-			Name:  "Andy",
-			Email: "Forest",
-		},
+		To:          user,
 		Attachments: nil,
 	})
 	suite.NoError(err)


### PR DESCRIPTION
Refactor Fields for create SMTP Send Email Query

Add struct for for an easier way to create a request structure

Problem: If now we try send email we get error 
```Http code: 422, url: /smtp/emails, body: "message":"Badly formed incoming data","error_code":999} ```

We get this error because sendpulse api wait for structure like this:
```
  "email": {
    "subject": "Test",
    "template": {
      "id": 123456,
      "variables": {
        "name": "Владислав",
        "code": "123456"
      }
    },
    "from": {
      "name": "Mike",
      "email": "mike.johnson@domain.com"
    },
    "to": [
      {
        "email": "recipient1@example.com",
        "name": "Владислав"
      }
    ]
  }
```
https://sendpulse.com/ru/integrations/api/smtp

How see, field "to" is array. Now it is a object