### PR TITLE
fix: company price to string

### DIFF
--- a/sms_service.go
+++ b/sms_service.go
@@ -297,7 +297,7 @@ type SmsCampaignInfo struct {
 	ID            int          `json:"id"`
 	AddressBookID int          `json:"address_book_id"`
 	Currency      string       `json:"currency"`
-	CompanyPrice  float32      `json:"company_price"`
+	CompanyPrice  string       `json:"company_price"`
 	SendDate      DateTimeType `json:"send_date"`
 	DateCreated   DateTimeType `json:"date_created"`
 	SenderName    string       `json:"sender_name"`


### PR DESCRIPTION
Send pulse has changed type of company_price field in response returning from "/sms/campaigns/info/%d" path
from float to string 
thats why i've changed it from float32 to string


