### PR TITLE
feat: add GetUnsubscribedEmail method to SmtpService

### DIFF
--- a/smtp_service.go
+++ b/smtp_service.go
@@ -250,6 +250,16 @@ func (service *SmtpService) GetUnsubscribedEmails(ctx context.Context, params Un
 	return respData, err
 }
 
+func (service *SmtpService) GetUnsubscribedEmail(ctx context.Context, email string) (bool, error) {
+	path := fmt.Sprintf("/smtp/unsubscribe/search?email=%s", email)
+
+	var respData struct {
+		Result bool `json:"result"`
+	}
+	_, err := service.client.newRequest(ctx, http.MethodGet, path, nil, &respData, true)
+	return respData.Result, err
+}
+
 func (service *SmtpService) GetSendersIPs(ctx context.Context) ([]string, error) {
 	path := "/smtp/ips"
 

--- a/smtp_service.go
+++ b/smtp_service.go
@@ -5,6 +5,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -251,8 +252,7 @@ func (service *SmtpService) GetUnsubscribedEmails(ctx context.Context, params Un
 }
 
 func (service *SmtpService) GetUnsubscribedEmail(ctx context.Context, email string) (bool, error) {
-	path := fmt.Sprintf("/smtp/unsubscribe/search?email=%s", email)
-
+	path := fmt.Sprintf("/smtp/unsubscribe/search?email=%s", url.QueryEscape(email))
 	var respData struct {
 		Result bool `json:"result"`
 	}

--- a/smtp_service_test.go
+++ b/smtp_service_test.go
@@ -3,9 +3,10 @@ package sendpulse_sdk_go
 import (
 	"context"
 	"fmt"
-	"github.com/bxcodec/faker/v3"
 	"net/http"
 	"time"
+
+	"github.com/bxcodec/faker/v3"
 )
 
 func (suite *SendpulseTestSuite) TestSmtpService_Send() {
@@ -326,4 +327,17 @@ func (suite *SendpulseTestSuite) TestSmtpService_VerifyDomain() {
 
 	err := suite.client.SMTP.VerifyDomain(context.Background(), email)
 	suite.NoError(err)
+}
+
+func (suite *SendpulseTestSuite) TestSmtpService_GetUnsubscribedEmail() {
+	email := "test@example.com"
+	suite.mux.HandleFunc("/smtp/unsubscribe/search", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(http.MethodGet, r.Method)
+		suite.Equal(email, r.URL.Query().Get("email"))
+		fmt.Fprintf(w, `{"result": true}`)
+	})
+
+	result, err := suite.client.SMTP.GetUnsubscribedEmail(context.Background(), email)
+	suite.NoError(err)
+	suite.True(result)
 }


### PR DESCRIPTION
This PR adds the GetUnsubscribedEmail method to SmtpService to check if a contact is in the list of unsubscribed users, along with a corresponding test.